### PR TITLE
Fixed bug and refactored ServerThread.removePerson(...)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build/
 /dist/
 *.ser
+persons.ser


### PR DESCRIPTION
The ServerThread.removePerson(...) method was calling the
DeviceHandler.SerializeDevice() method rather than the calling the
PersonHandler.SerializePerson() method.

Refactored the ServerThread.removePerson(...):
- fixed bug
- gave variables more descriptive names
- eliminated/reduced repeated code
